### PR TITLE
Remove MathJax from head/custom.html

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -28,15 +28,4 @@
 <meta name="theme-color" content="#ffffff">
 <link rel="stylesheet" href="{{ base_path }}/assets/css/academicons.css"/>
 
-<script type="text/x-mathjax-config"> MathJax.Hub.Config({ TeX: { equationNumbers: { autoNumber: "all" } } }); </script>
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {
-      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-      processEscapes: true
-    }
-  });
-</script>
-<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/latest.js?config=TeX-MML-AM_CHTML' async></script>
-
 <!-- end custom head snippets -->


### PR DESCRIPTION
## Summary
- Remove MathJax configuration and script tags from `_includes/head/custom.html` (lines 31-40)
- MathJax is not used on the site and adds unnecessary load time

Closes #22

## Test plan
- [ ] Verify the site builds without errors
- [ ] Confirm no pages relied on MathJax rendering

Generated with [Claude Code](https://claude.com/claude-code)