### PR TITLE
Disable unused collections in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -179,15 +179,6 @@ kramdown:
 
 # Collections
 collections:
-  teaching:
-    output: true
-    permalink: /:collection/:path/
-  publications:
-    output: true
-    permalink: /:collection/:path/
-  portfolio:
-    output: true
-    permalink: /:collection/:path/
   talks:
     output: true
     permalink: /:collection/:path/
@@ -212,34 +203,7 @@ defaults:
     values:
       layout: single
       author_profile: true
-  # _teaching
-  - scope:
-      path: ""
-      type: teaching
-    values:
-      layout: single
-      author_profile: true
-      share: true
-      comments: true
-  # _publications
-  - scope:
-      path: ""
-      type: publications
-    values:
-      layout: single
-      author_profile: true
-      share: true
-      comments: true
-  # _portfolio
-  - scope:
-      path: ""
-      type: portfolio
-    values:
-      layout: single
-      author_profile: true
-      read_time: true
-      comments: true
-      share: true
+
   # _talks
   - scope:
       path: ""


### PR DESCRIPTION
## Summary
- Remove `teaching`, `publications`, and `portfolio` entries from the `collections:` block in `_config.yml`
- Remove the corresponding `defaults:` entries for `_teaching`, `_publications`, and `_portfolio`
- Retain `posts`, `pages`, and `talks` defaults

Closes #20

## Test plan
- [ ] Verify site builds without errors (`bundle exec jekyll build`)
- [ ] Confirm talks, posts, and pages still render correctly
- [ ] Confirm no broken links to teaching/publications/portfolio pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)