### PR TITLE
Remove redundant Home nav entry

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,5 @@
-# main links links
+# main links
 main:
-  - title: "Home"
-    url: /
   - title: "Work"
     url: /work/
   - title: "Projects"


### PR DESCRIPTION
## Summary
- Remove the "Home" navigation item from the nav bar since clicking the site title already navigates to the homepage
- Fix minor typo in the YAML comment ("links links" -> "links")

Closes #27

## Test plan
- [ ] Verify the nav bar no longer shows a "Home" link
- [ ] Confirm clicking the site title still navigates to the homepage
- [ ] Check remaining nav items (Work, Projects, Research, Blog, Resume, Contact) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)