### PR TITLE
Clean up footer branding and sitemap link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,4 +21,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://github.com/academicpages/academicpages.github.io">AcademicPages</a>, a fork of <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}.</div>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,3 +1,2 @@
 <!-- start custom footer snippets -->
-<a href="/sitemap/">Sitemap</a>
 <!-- end custom footer snippets -->


### PR DESCRIPTION
## Summary
- Removed "Powered by Jekyll & AcademicPages, a fork of Minimal Mistakes" attribution from the footer, keeping only the copyright line
- Removed the sitemap link from the custom footer snippets

Closes #29

## Test plan
- [ ] Verify the footer renders with only the copyright notice
- [ ] Verify no sitemap link appears in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)