### PR TITLE
Set proper homepage title for SEO

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,6 @@
 ---
 permalink: /
-title: ""
+title: "Senior AI Engineer"
 excerpt: "Senior AI Engineer building production GenAI systems with measurable impact."
 author_profile: true
 redirect_from: 


### PR DESCRIPTION
## Summary
- Set the homepage `title` front matter from empty string to "Senior AI Engineer" in `_pages/about.md`
- This makes the HTML `<title>` render as "Senior AI Engineer - Ruan Chaves Rodrigues" instead of just the site name, improving SEO discoverability

Closes #21

## Test plan
- [ ] Verify the built site's `<title>` tag on the homepage contains "Senior AI Engineer - Ruan Chaves Rodrigues"
- [ ] Confirm the page still renders correctly with no layout issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)