### PR TITLE
Fix og:image fallback and SEO metadata gaps

### DIFF
--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -25,6 +25,10 @@
   {% assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
+{% if seo_description %}
+  <meta name="description" content="{{ seo_description }}">
+{% endif %}
+
 {% assign seo_author = page.author | default: page.author[0] | default: site.author[0] %}
 {% if seo_author %}
   {% if seo_author.twitter %}
@@ -87,6 +91,8 @@
   <meta property="og:image" content="{% if page.header.image contains "://" %}{{ page.header.image }}{% else %}{{ page.header.image | prepend: "/images/" | prepend: base_path }}{% endif %}">
 {% elsif page.header.overlay_image %}
   <meta property="og:image" content="{% if page.header.overlay_image contains "://" %}{{ page.header.overlay_image }}{% else %}{{ page.header.overlay_image | prepend: "/images/" | prepend: base_path }}{% endif %}">
+{% elsif site.og_image %}
+  <meta property="og:image" content="{{ site.og_image | prepend: "/images/" | prepend: base_path }}">
 {% endif %}
 
 {% if page.date %}


### PR DESCRIPTION
## Summary
- Add `og:image` fallback to `site.og_image` when no page header image is set, so the homepage and other pages get a share image in social previews
- Add standard `<meta name="description">` tag — previously only `og:description` was emitted, leaving the standard HTML meta description absent
- Verified `og_image: "profile.jpg"` in `_config.yml` matches the existing file `images/profile.jpg` and `author.avatar` — no config change needed
- `twitter.username` is intentionally empty (no Twitter/X account); the template already guards on that field so no twitter card metadata is emitted

## Test plan
- [ ] Build the site locally and inspect `<head>` of the homepage for `<meta name="description">`, `<meta property="og:description">`, and `<meta property="og:image">`
- [ ] Verify blog posts with header images still use the page-level image for `og:image`
- [ ] Run the URL through a social media debugger to confirm the share preview shows the profile image

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)