### PR TITLE
Fix sidebar employer field misusing location icon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -88,7 +88,7 @@ author:
   avatar           : "profile.jpg"
   bio              : "Senior AI Engineer focused on GenAI, RAG, agentic systems, and evidence-driven AI delivery."
   location         : "Brazil"
-  employer         : "Open to senior AI roles"
+  employer         :
   pubmed           :
   googlescholar    : "https://scholar.google.com/citations?user=3JDK8KEAAAAJ&hl=en"
   email            : "ruanchaves93@gmail.com"


### PR DESCRIPTION
## Summary
- Clears the `employer` field in `_config.yml` to remove the misleading "Open to senior AI roles" text that appeared with a map-marker icon in the sidebar.
- The employer field in Minimal Mistakes uses a map-marker/location icon, making the text confusing when repurposed for availability messaging.

Closes #24

## Test plan
- [ ] Verify the sidebar no longer shows "Open to senior AI roles" with a map-marker icon
- [ ] Confirm the location field ("Brazil") still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)