### PR TITLE
Remove sidebar author profile from all pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -202,7 +202,7 @@ defaults:
       type: pages
     values:
       layout: single
-      author_profile: true
+      author_profile: false
 
   # _talks
   - scope:
@@ -210,7 +210,7 @@ defaults:
       type: talks
     values:
       layout: talk
-      author_profile: true
+      author_profile: false
       share: true
 
 # Sass/SCSS

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,7 +2,6 @@
 permalink: /
 title: "Senior AI Engineer"
 excerpt: "Senior AI Engineer building production GenAI systems with measurable impact."
-author_profile: true
 redirect_from: 
   - /about.html
   - /about/

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Blog"
 permalink: /blog/
-author_profile: true
 excerpt: "Notes on evaluation, retrieval, prompting, and applied AI."
 ---
 

--- a/_pages/category-archive.html
+++ b/_pages/category-archive.html
@@ -2,7 +2,6 @@
 layout: archive
 permalink: /categories/
 title: "Posts by Category"
-author_profile: true
 ---
 
 {% include base_path %}

--- a/_pages/collection-archive.html
+++ b/_pages/collection-archive.html
@@ -2,7 +2,6 @@
 layout: archive
 title: "Posts by Collection"
 permalink: /collection-archive/
-author_profile: true
 ---
 
 {% include base_path %}

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Contact"
 permalink: /contact/
-author_profile: true
 excerpt: "Best ways to reach me for roles, consulting, or collaboration."
 ---
 

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Resume"
 permalink: /cv/
-author_profile: true
 redirect_from:
   - /resume
 excerpt: "Recruiter-ready summary, resume download, and core fit."

--- a/_pages/experience.md
+++ b/_pages/experience.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Work"
 permalink: /work/
-author_profile: true
 excerpt: "Quantified experience, leadership signals, and case studies."
 redirect_from:
   - /experience/

--- a/_pages/non-menu-page.md
+++ b/_pages/non-menu-page.md
@@ -2,7 +2,6 @@
 permalink: /non-menu-page/
 title: "Page not in menu"
 excerpt: "This is a page not in th emain menu"
-author_profile: true
 redirect_from: 
   - "/nmp/"
   - "/nmp.html"

--- a/_pages/portfolio.html
+++ b/_pages/portfolio.html
@@ -2,7 +2,6 @@
 layout: single
 title: "Portfolio"
 permalink: /portfolio/
-author_profile: true
 ---
 
 <p>The portfolio content now lives on the <a href="/projects/">projects page</a>.</p>

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Projects"
 permalink: /projects/
-author_profile: true
 excerpt: "Selected open-source and engineering proof."
 ---
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Publications"
 permalink: /publications/
-author_profile: true
 ---
 
 <p>This page now lives under <a href="/research/">research</a>.</p>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -2,7 +2,6 @@
 layout: single
 title: "Research"
 permalink: /research/
-author_profile: true
 excerpt: "Publications, awards, and research-backed credibility."
 ---
 

--- a/_pages/sitemap.md
+++ b/_pages/sitemap.md
@@ -2,7 +2,6 @@
 layout: archive
 title: "Sitemap"
 permalink: /sitemap/
-author_profile: true
 ---
 
 {% include base_path %}

--- a/_pages/subscribe.md
+++ b/_pages/subscribe.md
@@ -2,7 +2,6 @@
 permalink: /subscribe/
 title: ""
 excerpt: "Subscribe"
-author_profile: true
 redirect_from: 
   - /subscribe.html
 ---

--- a/_pages/tag-archive.html
+++ b/_pages/tag-archive.html
@@ -2,7 +2,6 @@
 layout: archive
 permalink: /tags/
 title: "Posts by Tags"
-author_profile: true
 ---
 
 {% include base_path %}

--- a/_pages/talkmap.html
+++ b/_pages/talkmap.html
@@ -2,7 +2,6 @@
 layout: archive
 title: "Talk map"
 permalink: /talkmap.html
-author_profile: true
 ---
 
 <p>This map is generated from a Jupyter Notebook file in <a href="https://github.com/academicpages/academicpages.github.io/blob/master/_talks/talkmap.ipynb">/_talks/talkmap.ipynb</a>, which mines the location fields in the .md files in _talks/.</p>

--- a/_pages/talks.html
+++ b/_pages/talks.html
@@ -2,7 +2,6 @@
 layout: single
 title: "Talks and presentations"
 permalink: /talks/
-author_profile: true
 ---
 
 <p>Talks and related material are grouped under <a href="/research/">research</a>.</p>

--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -2,7 +2,6 @@
 layout: archive
 title: "Teaching"
 permalink: /teaching/
-author_profile: true
 ---
 
 {% include base_path %}

--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -2,7 +2,6 @@
 layout: archive
 permalink: /archive/
 title: "Blog posts"
-author_profile: true
 redirect_from:
   - /wordpress/blog-posts/
   - /year-archive/

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -19,8 +19,8 @@
 .page {
   @include breakpoint($large) {
     @include span(10 of 12 last);
-    @include prefix(0.5 of 12);
-    @include suffix(2 of 12);
+    @include prefix(1 of 12);
+    @include suffix(1 of 12);
   }
 
   .page__inner-wrap {


### PR DESCRIPTION
## Summary
- Set `author_profile: false` in `_config.yml` defaults for both pages and talks sections
- Removed `author_profile: true` from the front matter of all 19 files in `_pages/`
- Updated `_sass/_page.scss` to center page content (prefix/suffix changed from 0.5/2 to 1/1 of 12)

Closes #42

## Test plan
- [ ] Verify no sidebar author profile (photo, bio, location, social links) appears on any page
- [ ] Verify page content is properly centered with the updated SCSS grid values
- [ ] Spot-check individual pages (about, blog, projects, research, contact) for correct rendering

Generated with [Claude Code](https://claude.com/claude-code)