### PR TITLE
Visual refresh: simplify landing page and align design system

### DIFF
--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -48,13 +48,13 @@
   /* for dark backgrounds */
 
   &--inverse {
-    color: $gray !important;
-    border: 1px solid $light-gray !important; /* override*/
+    color: $primary-color !important;
+    border: 1px solid mix(#fff, $primary-color, 60%) !important;
     background-color: #fff;
 
     &:hover {
       color: #fff !important;
-      border-color: $gray;
+      border-color: $primary-color;
     }
   }
 

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -175,7 +175,7 @@
 .greedy-nav {
   position: relative;
   min-width: 250px;
-  background: $background-color;
+  background: transparent;
 
   a {
     display: block;

--- a/_sass/_recruiter.scss
+++ b/_sass/_recruiter.scss
@@ -1,18 +1,16 @@
 :root {
-  --recruiter-bg: #f4efe6;
-  --recruiter-surface: #fffaf2;
-  --recruiter-card: #fffdf8;
+  --recruiter-bg: #f8f7f4;
+  --recruiter-surface: #ffffff;
+  --recruiter-card: #ffffff;
   --recruiter-ink: #17212b;
   --recruiter-muted: #596776;
-  --recruiter-border: #d9cdb8;
+  --recruiter-border: #e2e0db;
   --recruiter-accent: #0f4c5c;
   --recruiter-warm: #b96934;
 }
 
 body {
-  background:
-    radial-gradient(circle at top right, rgba(15, 76, 92, 0.08), transparent 24rem),
-    linear-gradient(180deg, #fbf7f0 0%, var(--recruiter-bg) 100%);
+  background: var(--recruiter-bg);
   color: var(--recruiter-ink);
   font-family: "Source Serif 4", Georgia, serif;
 }
@@ -36,8 +34,8 @@ h6,
 }
 
 .masthead {
-  border-bottom: 1px solid rgba(23, 33, 43, 0.08);
-  background: rgba(255, 250, 242, 0.84);
+  border-bottom: 1px solid var(--recruiter-border);
+  background: rgba(255, 255, 255, 0.88);
   backdrop-filter: blur(12px);
 }
 
@@ -62,13 +60,13 @@ h6,
 .metric-grid,
 .chip-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .landing-stage {
   grid-template-columns: minmax(0, 2.1fr) minmax(15rem, 1fr);
   align-items: start;
-  margin-bottom: 1.75rem;
+  margin-bottom: 2.5rem;
 }
 
 .recruiter-hero,
@@ -80,22 +78,21 @@ h6,
 .cta-panel,
 .post-feature,
 .metric-card {
-  padding: 1.25rem 1.35rem;
+  padding: 1.5rem 1.5rem;
   border: 1px solid var(--recruiter-border);
-  border-radius: 1.15rem;
+  border-radius: 0.75rem;
   background: var(--recruiter-card);
-  box-shadow: 0 10px 30px rgba(23, 33, 43, 0.04);
 }
 
 .recruiter-hero {
-  background: linear-gradient(145deg, #fffaf2 0%, #f7f0e4 100%);
+  padding: 2rem 1.75rem;
 }
 
 .recruiter-hero__title {
   margin: 0 0 0.75rem;
-  max-width: 19ch;
+  max-width: 22ch;
   font-size: clamp(1.9rem, 4vw, 3.05rem);
-  line-height: 1.02;
+  line-height: 1.08;
 }
 
 .recruiter-hero__summary,
@@ -111,18 +108,19 @@ h6,
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  margin-top: 1.25rem;
 }
 
 .signal-panel__metric + .signal-panel__metric {
   margin-top: 0.95rem;
   padding-top: 0.95rem;
-  border-top: 1px solid rgba(23, 33, 43, 0.08);
+  border-top: 1px solid var(--recruiter-border);
 }
 
 .signal-panel__value,
 .metric-card__value {
   margin: 0;
-  color: var(--recruiter-ink);
+  color: var(--recruiter-accent);
   font-size: 2rem;
   font-weight: 700;
   line-height: 1;
@@ -148,26 +146,24 @@ h6,
 
 .proof-bar {
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-  margin: 1.75rem 0 2rem;
+  margin: 0 0 2.5rem;
 }
 
 .proof-bar__item {
-  padding: 0.9rem 1rem;
-  border-top: 2px solid var(--recruiter-warm);
-  background: rgba(255, 253, 248, 0.9);
+  padding: 0.85rem 1rem;
+  border-left: 3px solid var(--recruiter-accent);
+  background: transparent;
   font-weight: 600;
+  font-size: 0.95rem;
 }
 
 .proof-bar--compact .proof-bar__item {
-  border-radius: 0.85rem;
-  border-right: 1px solid var(--recruiter-border);
-  border-bottom: 1px solid var(--recruiter-border);
-  border-left: 1px solid var(--recruiter-border);
+  border-radius: 0;
 }
 
 .feature-grid {
   grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-  margin: 1rem 0 2rem;
+  margin: 1rem 0 2.5rem;
 }
 
 .feature-card h2,
@@ -185,7 +181,7 @@ h6,
 
 .editorial-grid {
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-  margin: 1.25rem 0 2rem;
+  margin: 1.25rem 0 2.5rem;
 }
 
 .content-panel--dense,
@@ -197,11 +193,11 @@ h6,
 .highlight-list p {
   margin: 0 0 0.85rem;
   padding-left: 0.95rem;
-  border-left: 3px solid var(--recruiter-warm);
+  border-left: 3px solid var(--recruiter-accent);
 }
 
 .case-study {
-  margin: 1rem 0 1.25rem;
+  margin: 1rem 0 1.5rem;
 }
 
 .case-study__outcome {
@@ -263,8 +259,7 @@ h6,
 
 .post-feature,
 .cta-panel {
-  margin: 1rem 0 1.5rem;
-  background: linear-gradient(180deg, #fff7ec 0%, var(--recruiter-card) 100%);
+  margin: 1rem 0 2rem;
 }
 
 .archive-row {
@@ -272,7 +267,7 @@ h6,
   grid-template-columns: 4.5rem minmax(0, 1fr);
   gap: 1rem;
   padding: 0.85rem 0;
-  border-top: 1px solid rgba(23, 33, 43, 0.08);
+  border-top: 1px solid var(--recruiter-border);
 }
 
 .archive-row__body h3 {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -60,7 +60,7 @@ $code-background-color-dark : $light-gray;
 $text-color                 : $dark-gray;
 $border-color               : $lighter-gray;
 
-$primary-color              : #7a8288;
+$primary-color              : #0f4c5c;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
@@ -90,11 +90,11 @@ $xing-color                 : #006567;
 
 
 /* links */
-$link-color                 : $info-color;
+$link-color                 : #0f4c5c;
 $link-color-hover           : mix(#000, $link-color, 25%);
 $link-color-visited         : mix(#fff, $link-color, 25%);
-$masthead-link-color        : $primary-color;
-$masthead-link-color-hover  : mix(#000, $primary-color, 25%);
+$masthead-link-color        : #17212b;
+$masthead-link-color-hover  : #0f4c5c;
 
 
 /*


### PR DESCRIPTION
## Summary
- Set `$primary-color` and `$link-color` to recruiter accent (`#0f4c5c`) and update masthead link colors for contrast
- Simplified `_recruiter.scss`: flat white backgrounds, cleaner spacing, accent-colored metric values, border-left proof bars
- Made greedy-nav background transparent so masthead backdrop-blur shows through
- Updated inverse button to use `$primary-color` instead of `$gray`

Closes #43

## Test plan
- [ ] Verify landing page renders with flat white card backgrounds (no gradients or box-shadows)
- [ ] Confirm links, buttons, and masthead use the teal accent color (#0f4c5c)
- [ ] Check masthead blur effect is visible (transparent nav background)
- [ ] Test responsive layout at < 840px breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)