### PR TITLE
Remove Susy grid sidebar layout, use full-width centering

### DIFF
--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -4,15 +4,9 @@
 
 .archive {
   margin-bottom: 2em;
-
-  @include breakpoint($medium) {
-    @include span(12 of 12);
-  }
-
-  @include breakpoint($large) {
-    @include span(10 of 12 last);
-    @include prefix(0.5 of 12);
-  }
+  max-width: 58rem;
+  margin-left: auto;
+  margin-right: auto;
 
   a {
     text-decoration: underline;

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -32,14 +32,6 @@
     padding: 0;
     list-style: none;
     font-size: $type-size-6;
-
-    @include breakpoint($large) {
-      @include span(10 of 12 last);
-    }
-
-    @include breakpoint($x-large) {
-      @include prefix(0.5 of 12);
-    }
   }
 
   li {

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -3,35 +3,20 @@
    ========================================================================== */
 
 #main {
-  @include container;
-  @include clearfix;
+  max-width: 62rem;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: 2em;
-  padding-left: 1em;
-  padding-right: 1em;
+  padding-left: 1.5em;
+  padding-right: 1.5em;
   animation: intro 0.3s both;
   animation-delay: 0.35s;
-
-  @include breakpoint($x-large) {
-    max-width: $x-large;
-  }
 }
 
 .page {
-  @include breakpoint($large) {
-    @include span(10 of 12 last);
-    @include prefix(1 of 12);
-    @include suffix(1 of 12);
-  }
-
-  .page__inner-wrap {
-    @include full();
-
-    .page__content,
-    .page__meta,
-    .page__share {
-      @include full();
-    }
-  }
+  max-width: 58rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .page__title {
@@ -383,12 +368,6 @@
   margin-top: 2em;
   padding-top: 1em;
   border-top: 1px solid $border-color;
-  @include clearfix();
-  float: left;
-
-  @include breakpoint($large) {
-    @include pre(2.5 of 12);
-  }
 
   a {
     color: inherit;


### PR DESCRIPTION
## Summary
- Replaced Susy grid `span(10 of 12 last)` positioning on `.page`, `.archive`, and breadcrumbs with `max-width` + `margin: auto` centering
- Removed `float: left` and `@include pre(2.5 of 12)` from `.page__related` 
- Widened `#main` container from 925px Susy container to `62rem`
- Content now fills available width up to `58rem`, centered — no more ghost sidebar column

The sidebar was removed in PR #44 but the CSS still reserved ~17% of the width for it.

## Test plan
- [ ] Verify landing page content spans full width (no gap on left)
- [ ] Verify inner pages (Work, Projects, Blog, CV) are centered
- [ ] Verify mobile layout still stacks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)