### PR TITLE
Group skills by category on Work and Resume pages

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -55,13 +55,14 @@ excerpt: "Recruiter-ready summary, resume download, and core fit."
 
 ## Skills
 
-<div class="chip-grid">
 {% for group in candidate.skills %}
+<p class="panel-label">{{ group.category }}</p>
+<div class="chip-row">
   {% for item in group.items %}
   <span class="chip">{{ item }}</span>
   {% endfor %}
-{% endfor %}
 </div>
+{% endfor %}
 
 <section class="editorial-grid">
   <div class="content-panel content-panel--dense">

--- a/_pages/experience.md
+++ b/_pages/experience.md
@@ -60,10 +60,11 @@ redirect_from:
 
 ## Strengths
 
-<div class="chip-grid">
 {% for group in candidate.skills %}
+<p class="panel-label">{{ group.category }}</p>
+<div class="chip-row">
   {% for item in group.items %}
   <span class="chip">{{ item }}</span>
   {% endfor %}
-{% endfor %}
 </div>
+{% endfor %}

--- a/_sass/_recruiter.scss
+++ b/_sass/_recruiter.scss
@@ -242,6 +242,13 @@ h6,
   margin: 1rem 0 1.5rem;
 }
 
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
 .chip,
 .inline-chip {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Replace flat `chip-grid` with category-labeled `chip-row` sections in `_pages/experience.md` (Strengths) and `_pages/cv.md` (Skills)
- Add `.chip-row` CSS class (flex-wrap layout) to `_sass/_recruiter.scss`
- Skills now render grouped under their category headings (GenAI and Agentic Systems, Frameworks and APIs, ML and Data, Cloud and Delivery)

Closes #51

## Test plan
- [ ] Verify `/work/` page shows skills grouped by category with labels
- [ ] Verify `/cv/` page shows skills grouped by category with labels
- [ ] Confirm chip-row styling renders correctly (flex-wrap with gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)